### PR TITLE
Add basic screenshot capability for Virtualbox 6.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,19 +1,13 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [dev-packages]
 
-
-
 [packages]
-
 zeep = "*"
-
+semver = "*"
 
 [requires]
-
 python_version = "2.7"

--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,15 @@ Usage example
 .. code:: python
 
         >>> import remotevbox
-        >>> vbox = remotevbox.connect("https://127.0.0.1:18083", "vbox", "yourpassphrase")
+        >>> vbox = remotevbox.connect("http://127.0.0.1:18083", "vbox", "yourpassphrase")
         >>> vbox.get_version()
-        '5.1.30'
+        '6.1.2'
         >>> machine = vbox.get_machine("Windows10")
         >>> machine.launch()
+        >>> screenshot_data = machine.take_screenshot_to_bytes()
+        >>> fp = open('screenshot.png', 'wb')
+        >>> fp.write(screenshot_data)
+        >>> fp.close()
         >>> machine.save()
         >>> vbox.disconnect()
 

--- a/remotevbox/vbox.py
+++ b/remotevbox/vbox.py
@@ -7,13 +7,12 @@ import zeep
 
 from .machine import IMachine
 from .websession_manager import IWebsessionManager
-from .exceptions import (FindMachineError, ListMachinesError, WebServiceConnectionError)
+from .exceptions import FindMachineError, ListMachinesError, WebServiceConnectionError
 
 VBOX_SOAP_BINDING = "{http://www.virtualbox.org/}vboxBinding"
 
 
 class IVirtualBox(object):
-
     def __init__(self, location, user="", password=""):
 
         if not location.endswith("/"):
@@ -25,6 +24,7 @@ class IVirtualBox(object):
         self.manager = IWebsessionManager(self.service, user, password)
 
         self.handle = self.manager.handle
+        self.version = self.get_version()
 
     def get_client(self, location):
         try:
@@ -59,7 +59,7 @@ class IVirtualBox(object):
     def get_machine(self, name):
         """Returns IMachine"""
         mid = self.find_machine(name)
-        return IMachine(self.service, self.manager, mid)
+        return IMachine(self.service, self.manager, mid, vbox_version=self.version)
 
     def find_machine(self, name):
         """Returns virtual machine identificator by it's name"""


### PR DESCRIPTION
As per issue #6 , this adds the possibility to take a screenshot to the machine. I also updated to the latest stable (Virtualbox 6.1). This required a small change to avoid the weird `VERR_ENV_INVALID_VAR_NAME`

Was a bit hard to implement because I got locking error when taking the screenshot, eventually I examined the calls from an [Android client](https://github.com/kedzie/VBoxManager) and was able to get it.

By default, the image has the same size of the screen and in case of multiple screen the screen with id 0 is used.

I kept the change minimal, I'm interested in adding more stuff but will open separate issues for that.