### PR TITLE
Update deprecated semver usage

### DIFF
--- a/remotevbox/machine.py
+++ b/remotevbox/machine.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from time import mktime, sleep
 
 import zeep.exceptions
-import semver
+from semver import VersionInfo
 
 from .exceptions import (
     MachineCloneError,
@@ -78,7 +78,7 @@ class IMachine(object):
             return
 
         try:
-            if semver.compare(self.vbox_version, "6.1.0") == -1:
+            if VersionInfo.parse(self.vbox_version).compare("6.1.0") == -1:
                 progress = self.service.IMachine_launchVMProcess(
                     self.mid, self.session, mode, "",
                 )


### PR DESCRIPTION
The semver module now complains that the usage of compare is deprecated, and will be deleted in a future version.
This is now the suggested usage.